### PR TITLE
Add navigation pages for packages and consultation

### DIFF
--- a/src/app/consultation/page.tsx
+++ b/src/app/consultation/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function ConsultationPage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-8">
+      <h1 className="text-4xl font-bold mb-4 text-center">Free Consultation</h1>
+      <p className="text-blue-200 mb-8 text-center">Schedule your complimentary security assessment and receive a customized protection plan.</p>
+      <div className="text-center space-x-4">
+        <a href="mailto:info@securesavannah.com" className="px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold inline-block">Email Us</a>
+        <Link href="/" className="px-8 py-3 border border-blue-400 text-blue-400 rounded-lg font-semibold inline-block hover:bg-blue-400 hover:text-slate-900">Back to Home</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -1,6 +1,7 @@
 // The exported code uses Tailwind CSS. Install Tailwind CSS in your dev environment to ensure all styles work.
 "use client";
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -19,6 +20,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 const HomePage: React.FC = () => {
+  const router = useRouter();
   const [selectedPackage, setSelectedPackage] = useState<string>('');
 
   const handlePackageSelect = (pkg: string) => {
@@ -79,10 +81,10 @@ const HomePage: React.FC = () => {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 justify-center lg:justify-start">
-              <button className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors">
+              <button onClick={() => router.push('/packages')} className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors">
                 View Packages
               </button>
-              <button className="px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-slate-900 font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors">
+              <button onClick={() => router.push('/consultation')} className="px-8 py-4 border-2 border-white text-white hover:bg-white hover:text-slate-900 font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors">
                 Free Consultation
               </button>
             </div>
@@ -194,7 +196,7 @@ const HomePage: React.FC = () => {
                 </li>
               </ul>
               <button
-                onClick={() => handlePackageSelect('Essential')}
+                onClick={() => {handlePackageSelect('Essential'); router.push('/packages/essential');}}
                 className="w-full py-4 font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors bg-blue-600 hover:bg-blue-700 text-white"
               >
                 Get Started
@@ -234,7 +236,7 @@ const HomePage: React.FC = () => {
                 </li>
               </ul>
               <button
-                onClick={() => handlePackageSelect('Professional')}
+                onClick={() => {handlePackageSelect('Professional'); router.push('/packages/professional');}}
                 className="w-full py-4 font-semibold rounded-lg whitespace-nowrap cursor-pointer transition-colors bg-blue-600 hover:bg-blue-700 text-white"
               >
                 Get Started
@@ -269,7 +271,7 @@ const HomePage: React.FC = () => {
                 </li>
               </ul>
               <button
-                onClick={() => handlePackageSelect('Custom')}
+                onClick={() => {handlePackageSelect('Custom'); router.push('/consultation');}}
                 className="w-full py-4 bg-white text-blue-600 font-semibold rounded-lg whitespace-nowrap cursor-pointer hover:bg-blue-50 transition-colors"
               >
                 Schedule Consultation
@@ -394,7 +396,7 @@ const HomePage: React.FC = () => {
                 <p className="text-base text-blue-100 mb-6 sm:text-lg"> {/* <-- FONT SIZE */}
                     Schedule your complimentary security assessment and receive a customized protection plan for your property.
                 </p>
-                <button className="w-full sm:w-auto px-8 py-3 bg-white text-blue-600 font-semibold rounded-lg cursor-pointer hover:bg-blue-50 transition-colors"> {/* <-- RESPONSIVE WIDTH */}
+                <button onClick={() => router.push('/consultation')} className="w-full sm:w-auto px-8 py-3 bg-white text-blue-600 font-semibold rounded-lg cursor-pointer hover:bg-blue-50 transition-colors"> {/* <-- RESPONSIVE WIDTH */}
                     Schedule Free Consultation
                 </button>
             </div>

--- a/src/app/packages/essential/page.tsx
+++ b/src/app/packages/essential/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function EssentialPackage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-8">
+      <h1 className="text-4xl font-bold mb-4 text-center">Essential Package</h1>
+      <p className="text-blue-200 mb-8 text-center">Professional doorbell camera installation with garage monitoring and AI motion alerts.</p>
+      <div className="text-center">
+        <Link href="/consultation" className="px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold">Schedule Consultation</Link>
+      </div>
+      <div className="mt-12 text-center">
+        <Link href="/packages" className="text-blue-400 hover:underline">Back to Packages</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/packages/page.tsx
+++ b/src/app/packages/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function PackagesPage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-8">
+      <h1 className="text-4xl font-bold mb-8 text-center">Installation Packages</h1>
+      <p className="mb-8 text-center text-blue-200">Choose the security solution that fits your needs.</p>
+      <div className="max-w-4xl mx-auto grid gap-8 md:grid-cols-2">
+        <Link href="/packages/essential" className="block p-6 bg-slate-800 rounded-xl hover:bg-slate-700 transition">
+          <h2 className="text-2xl font-semibold mb-2">Essential Package</h2>
+          <p>Professional doorbell camera installation and single garage monitoring.</p>
+        </Link>
+        <Link href="/packages/professional" className="block p-6 bg-slate-800 rounded-xl hover:bg-slate-700 transition">
+          <h2 className="text-2xl font-semibold mb-2">Professional Package</h2>
+          <p>Everything in Essential plus four additional 4K cameras and advanced NVR.</p>
+        </Link>
+      </div>
+      <div className="mt-12 text-center">
+        <Link href="/" className="text-blue-400 hover:underline">Back to Home</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/packages/professional/page.tsx
+++ b/src/app/packages/professional/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function ProfessionalPackage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-8">
+      <h1 className="text-4xl font-bold mb-4 text-center">Professional Package</h1>
+      <p className="text-blue-200 mb-8 text-center">Includes everything in Essential plus four 4K cameras and advanced NVR with AI object recognition.</p>
+      <div className="text-center">
+        <Link href="/consultation" className="px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold">Schedule Consultation</Link>
+      </div>
+      <div className="mt-12 text-center">
+        <Link href="/packages" className="text-blue-400 hover:underline">Back to Packages</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wire homepage buttons to navigate to package and consultation pages
- add dedicated pages for packages (main, essential, professional) and consultation to reach five SEO-friendly pages

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` font)


------
https://chatgpt.com/codex/tasks/task_e_68a59cc41fc0832790800b11203e3bfa